### PR TITLE
BLOB/TEXT column 'data' can't have a default value

### DIFF
--- a/lib/merb_datamapper/data_mapper_session.rb
+++ b/lib/merb_datamapper/data_mapper_session.rb
@@ -11,7 +11,7 @@ module Merb
     storage_names[default_repository_name] = Merb::Plugins.config[:merb_datamapper][:session_storage_name]
 
     property :session_id, String, :length => 32, :required => true, :key => true
-    property :data, Object, :default => {}, :lazy => false
+    property :data, Object, :lazy => false
     property :created_at, DateTime, :default => Proc.new { |r, p| DateTime.now }
 
     ##
@@ -22,7 +22,7 @@ module Merb
     # @returns <nil, DataMapperSessionStore> The session corresponding to the id, or nil
     def self.retrieve_session(session_id)
       if session = get(session_id)
-        session.data
+        session.data || {}
       end
     end
 


### PR DESCRIPTION
mySQL complains on the title when db:automigrate with c[:session_store] = 'datamapper'

:data property should not have a default value.
Anyway there is no reason to serialize empty {} and store it to DB.

http://github.com/ujifgc/merb_datamapper/commit/fc93b276779cea43b21bdc71437ccf9b7ba527be
