### PR TITLE
Fixes session store setup

### DIFF
--- a/lib/merb_datamapper/data_mapper_session.rb
+++ b/lib/merb_datamapper/data_mapper_session.rb
@@ -11,7 +11,7 @@ module Merb
     storage_names[default_repository_name] = Merb::Plugins.config[:merb_datamapper][:session_storage_name]
 
     property :session_id, String, :length => 32, :required => true, :key => true
-    property :data, Object, :default => {}, :lazy => false
+    property :data, Object, :default => Proc.new { {} }, :lazy => false
     property :created_at, DateTime, :default => Proc.new { |r, p| DateTime.now }
 
     ##


### PR DESCRIPTION
MySQL does not allow a text field to have a default value with some combinations of storage engine and strict mode (Amazon's RDS config).

http://bugs.mysql.com/bug.php?id=25520

This changes the the default to be set by a proc on init, instead of assigning it as a table column default.
